### PR TITLE
Prevent from redirect loop

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -134,7 +134,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $url = $referrer ? $this->to($referrer) : $this->getPreviousUrlFromSession();
 
-        return $url ?: $this->to('/');
+        return ($url && $url != $this->current()) ? $url : $this->to('/');
     }
 
     /**


### PR DESCRIPTION
This code `return app('redirect')->back()` can produce redirect loop if the previous visited URL is the same as the current URL.